### PR TITLE
Updating NAT rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Fill in `Servers` with your selected TCP/UDP servers and `Use DoH Server` with y
 Or use the terminal to achieve the same config.
 
 ## Redirecting all TCP/UDP DNS requests to your router
-## The following NAT rules will redirect all UDP / TCP requests with port 53 as destination ##
-## The prior NAT rules will work in a ROS VLAN environment ##
+## The following NAT rules will redirect all UDP / TCP requests with port 53 to the router as destination ##
+## The prior NAT rules will NOT work in a ROS VLAN environment ##
 
 You can do this via IP -> Firewall -> Nat on WebFig, or via terminal (SSH/web) with:
 ```

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Fill in `Servers` with your selected TCP/UDP servers and `Use DoH Server` with y
 Or use the terminal to achieve the same config.
 
 ## Redirecting all TCP/UDP DNS requests to your router
-
-Assuming the router is on `192.168.88.1`.
+## The following NAT rules will redirect all UDP / TCP requests with port 53 as destination ##
+## The prior NAT rules will work in a ROS VLAN environment ##
 
 You can do this via IP -> Firewall -> Nat on WebFig, or via terminal (SSH/web) with:
 ```
 /ip firewall nat
-add chain=dstnat action=dst-nat to-addresses=192.168.88.1 to-ports=53 protocol=udp dst-port=53 log=no log-prefix="" 
-add chain=dstnat action=dst-nat to-addresses=192.168.88.1 to-ports=53 protocol=tcp dst-port=53 log=no log-prefix="" 
+add action=redirect chain=dstnat dst-port=53 protocol=udp to-ports=53
+add action=redirect chain=dstnat dst-port=53 protocol=tcp to-ports=53
 ```
 
 ## Blocking DoH requests via address list

--- a/scripts/generate_for_router.sh
+++ b/scripts/generate_for_router.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ]
-  then
-    echo "No argument supplied"
-    echo "usage: ./generate_for_router.sh router_internal_ip"
-    exit 1 
-fi
-
-
 echo "Redirect all port 53 DNS traffic to router"
 echo '/ip firewall nat' > mikrotik_all_commands.txt
-echo 'add chain=dstnat action=dst-nat to-addresses=192.168.88.1 to-ports=53 protocol=udp dst-port=53 log=no log-prefix="" ' >> mikrotik_all_commands.txt
-echo 'add chain=dstnat action=dst-nat to-addresses=192.168.88.1 to-ports=53 protocol=tcp dst-port=53 log=no log-prefix="" ' >> mikrotik_all_commands.txt
+
+/ip firewall nat
+echo 'add action=redirect chain=dstnat dst-port=53 protocol=udp to-ports=53' >> mikrotik_all_commands.txt
+echo 'add action=redirect chain=dstnat dst-port=53 protocol=tcp to-ports=53' >> mikrotik_all_commands.txt
 
 echo "Add firewall rule to block DoH via address list"
 echo '/ip firewall filter'>> mikrotik_all_commands.txt


### PR DESCRIPTION
The prior NAT rules will not work in a ROS VLAN environment. The best way to guarantee that no user will bypass plain text DNS requests is to redirect the traffic flow to the router itself. Still, you can create multiple NAT rules based on the source address / list.