### PR TITLE
Change data source to a more comprehensive and automatically updated one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ E.g.:
 /ip firewall address-list add address=dns.google list="DoH Servers"
 ``` 
 
-See the commands for adding a full list at [mirotik_doh_list_commands.txt](mikrotik_doh_list_commands.txt) based on data from [https://github.com/oneoffdallas/dohservers](https://github.com/oneoffdallas/dohservers) (see bellow for acknowlegements and license details).
+See the commands for adding a full list at [mirotik_doh_list_commands.txt](mikrotik_doh_list_commands.txt) based on data from [https://github.com/dibdot/DoH-IP-blocklists](https://github.com/dibdot/DoH-IP-blocklists) (see bellow for acknowlegements and license details).
 
 ## Scripts
 
@@ -48,7 +48,7 @@ All scripts sit under the `./scripts/` folder.
 
 ### `get_list.sh`
 
-Gets current master of `iplist.txt` from [https://github.com/oneoffdallas/dohservers](https://github.com/oneoffdallas/dohservers).
+Gets current master of `iplist.txt` from [https://github.com/dibdot/DoH-IP-blocklists](https://github.com/dibdot/DoH-IP-blocklists).
 
 ### `process_doh_list.sh`
 
@@ -76,4 +76,4 @@ You can find nice public servers at [Public DNS at European Alternatives](https:
 
 - [Mikrotik](https://mikrotik.com) for making awesome network hardware.
 - [https://european-alternatives.eu](https://european-alternatives.eu) for collecting nice alternatives under one site.
-- [https://github.com/oneoffdallas/dohservers](https://github.com/oneoffdallas/dohservers) for making available the data under their [MIT LICENSE](https://github.com/oneoffdallas/dohservers/blob/master/LICENSE).
+- [https://github.com/dibdot/DoH-IP-blocklists](https://github.com/dibdot/DoH-IP-blocklists) for making the output of their program available.

--- a/scripts/get_list.sh
+++ b/scripts/get_list.sh
@@ -2,7 +2,7 @@
 
 curl --version || { echo "Please install curl" ; exit 1; }
 
-curl https://raw.githubusercontent.com/oneoffdallas/dohservers/master/iplist.txt -o iplist.txt
+curl https://raw.githubusercontent.com/dibdot/DoH-IP-blocklists/refs/heads/master/doh-ipv4.txt -o iplist.txt
 echo "===================================================================="
 echo "Remember to uncomment lines in iplist.txt for cloudflare if you want"
 echo "===================================================================="

--- a/scripts/process_doh_list.sh
+++ b/scripts/process_doh_list.sh
@@ -6,8 +6,8 @@ gawk --version >> /dev/null || { echo "Please install awk" ; exit 1; }
 
 echo "Processing..."
 
-cat iplist.txt | grep -v '^\s*#' | sed 's/\s\(\S\)/\1/' | gawk '{print $1}' > full_list.txt
-cat mylist.txt | grep -v '^\s*#' | sed 's/\s\(\S\)/\1/' | gawk '{print $1}' >> full_list.txt
+cat iplist.txt | grep -v '^\s*#' | gawk '{print $1}' > full_list.txt
+cat mylist.txt | grep -v '^\s*#' | gawk '{print $1}' >> full_list.txt
 gawk -i inplace 'FNR==1{delete a} !a[$0]++' full_list.txt
 
 echo "/ip firewall address-list remove [find where list="DoH Servers"]" > mikrotik_doh_list_commands.txt

--- a/scripts/process_doh_list.sh
+++ b/scripts/process_doh_list.sh
@@ -2,14 +2,16 @@
 
 grep --version >> /dev/null || { echo "Please install grep" ; exit 1; }
 sed --version >> /dev/null || { echo "Please install sed" ; exit 1; }
+gawk --version >> /dev/null || { echo "Please install awk" ; exit 1; }
 
 echo "Processing..."
 
-echo "/ip firewall address-list" > mikrotik_doh_list_commands.txt
-cat iplist.txt | grep -v '#' | grep '\S' | sed 's/\s\(\S\)/\1/' > full_list.txt
-cat mylist.txt | grep -v '#' >> full_list.txt
+cat iplist.txt | grep -v '^\s*#' | sed 's/\s\(\S\)/\1/' | gawk '{print $1}' > full_list.txt
+cat mylist.txt | grep -v '^\s*#' | sed 's/\s\(\S\)/\1/' | gawk '{print $1}' >> full_list.txt
+gawk -i inplace 'FNR==1{delete a} !a[$0]++' full_list.txt
 
+echo "/ip firewall address-list remove [find where list="DoH Servers"]" > mikrotik_doh_list_commands.txt
+echo "/ip firewall address-list" >> mikrotik_doh_list_commands.txt
 cat full_list.txt | sort -u | xargs -I% echo 'add address=% list="DoH Servers"' >> mikrotik_doh_list_commands.txt
-
 
 echo "All done"


### PR DESCRIPTION
This PR covers a change of data source to the one in [this repository](https://github.com/dibdot/DoH-IP-blocklists), for the following reasons:

- The source uses `dig` to construct a list of addresses
- The source set Github Actions up to continuously update the list.

Also somewhat changed how the new list of addresses is processed:

- Changed the `grep` regex to be more explicit - it now filters all the files that explicitly start with 0-or-more whitespace followed by a `#`; without this it would filter the entirety of the new data set because a `#` exists after the IP address;
- Added a `gawk` step to select the first column off the set because it was simpler than writing a regex
- Added a final `gawk` step that replaces duplicates in place; otherwise the command sent to the router fails whenever a repeat address occurs.

Finally, added a command that instructs the router to clear the existing list in order to prevent IP staleness or errors.